### PR TITLE
feat: add tweets seeder

### DIFF
--- a/seeders/20230606003524-tweets-seed-file.js
+++ b/seeders/20230606003524-tweets-seed-file.js
@@ -1,0 +1,31 @@
+'use strict'
+const faker = require('faker')
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const userData = await queryInterface.sequelize.query(
+      "SELECT id FROM Users WHERE role = '普通會員';",
+      { type: queryInterface.sequelize.QueryTypes.SELECT }
+    )
+    // 預設一人10篇tweets
+    const DEFAULT_TWEETS_FOR_EACH_PERSON = 10
+    const TWEETS_WORD_LIMIT = 140
+    const tweetsSeeder = []
+
+    userData.forEach(user => {
+      for (let i = 0; i < DEFAULT_TWEETS_FOR_EACH_PERSON; i++) {
+        tweetsSeeder.push({
+          UserId: user.id,
+          description: faker.lorem.sentence().substring(0, TWEETS_WORD_LIMIT),
+          createdAt: faker.date.past(),
+          updatedAt: faker.date.recent()
+        })
+      }
+    })
+    await queryInterface.bulkInsert('tweets', tweetsSeeder)
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('tweets', {})
+  }
+}


### PR DESCRIPTION
新增 tweets 種子資料：
1. 綁入user假資料（userId, role= '普通會員')
2. 字數限制
3. 預設每人10 篇