### PR TITLE
feat: add replies seed

### DIFF
--- a/seeders/20230606075855-replies-seed-file.js
+++ b/seeders/20230606075855-replies-seed-file.js
@@ -1,0 +1,30 @@
+'use strict'
+const DEFAULT_REPLAIES_FOR_EACH_TWEET = 3
+const DEFAULT_WORD_LIMIT = 50
+
+const faker = require('faker')
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    const users = await queryInterface.sequelize.query(
+      "SELECT id FROM Users WHERE role = '普通會員';",
+      { type: queryInterface.sequelize.QueryTypes.SELECT }
+    )
+    const tweets = await queryInterface.sequelize.query(
+      'SELECT id FROM Tweets;',
+      { type: queryInterface.sequelize.QueryTypes.SELECT }
+    )
+    const totalReplies = tweets.length * DEFAULT_REPLAIES_FOR_EACH_TWEET
+    await queryInterface.bulkInsert('Replys',
+      Array.from({ length: totalReplies }, (_, index) => ({
+        UserId: users[Math.floor(Math.random() * users.length)].id,
+        TweetId: tweets[Math.floor(index / DEFAULT_REPLAIES_FOR_EACH_TWEET)].id,
+        comment: faker.lorem.sentence().substring(0, DEFAULT_WORD_LIMIT),
+        createdAt: faker.date.past(),
+        updatedAt: faker.date.recent()
+      })))
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.bulkDelete('Replys', {})
+  }
+}


### PR DESCRIPTION
簡單說一下我建立的想法：
目標條件（user stories) ：每篇tweet有隨機3個留言，每個人有1則留言

> Array.from做150則留言，
其中TweetId : tweets[Math.floor(index / DEFAULT_REPLAIES_FOR_EACH_TWEET)].id
reply index 0, 1, 2 會屬於一個tweet.id
reply index 3, 4, 5 會屬於另一個tweet.id 
以此類推

>內容字數設定50是暫時不想讓資料體積太龐大，不是規定需求，可以視前端需求調整
>然後就是role 還沒改版，用之前的'普通會員'，需要後面一起調整成'user'